### PR TITLE
The effect of generic anti-replay

### DIFF
--- a/draft-thomson-http-replay.md
+++ b/draft-thomson-http-replay.md
@@ -104,7 +104,9 @@ replay is judged too great.
 4. Finally, TLS {{?TLS13}} describes several mitigation strategies that reduce
 the ability of an attacker to successfully replay early data. Servers are
 strongly encouraged to implement these techniques, but to also recognize that
-they are imperfect.
+they are imperfect. These anti-replay techniques can reduce the number of
+replays that will be successful from being essentially unbounded to a fixed
+value.
 
 For a given request, the level of tolerance to replay risk is specific to the
 resource it operates upon (and therefore only known to the origin server). In


### PR DESCRIPTION
... is that replays are reduced from effectively unbounded, to a fixed
value.  This is a key point in the discussion of replays in TLS and
worth repeating here.

For @kaduk