### PR TITLE
On requests that are only partially in 0-RTT

### DIFF
--- a/draft-thomson-http-replay.md
+++ b/draft-thomson-http-replay.md
@@ -120,6 +120,13 @@ whether early data is appropriate in requests. Absent such explicit
 information, they SHOULD mitigate against early data in requests that have
 unsafe methods, using the techniques outlined above.
 
+A request might be sent partially in early data with the remainder of the
+request being sent after the handshake completes.  This does not necessarily
+affect handling of that request; what matters is when the server starts acting
+upon the contents of a request.  Any time a server might initiate processing
+prior to completion of the handshake needs to consider how a possible replay of
+early data could affect that processing.
+
 Intermediary servers do not have sufficient information to make this
 determination, so {{status}} describes a way for the origin to signal to them
 that a particular request isn't appropriate for early data. Intermediaries that


### PR DESCRIPTION
Fundamentally, these don't need special treatment, but we should say
that.

Closes #16.