### PR TITLE
Save the 'be consistent' text

### DIFF
--- a/draft-thomson-http-replay.md
+++ b/draft-thomson-http-replay.md
@@ -140,7 +140,7 @@ request being sent after the handshake completes.  This does not necessarily
 affect handling of that request; what matters is when the server starts acting
 upon the contents of a request.  Any time a server might initiate processing
 prior to completion of the handshake needs to consider how a possible replay of
-early data could affect that processing.
+early data could affect that processing (see also {{be-consistent}}).
 
 A server can partially process requests that are incomplete.  Parsing header
 fields - without acting on the values - and determining request routing is
@@ -311,14 +311,13 @@ forwarding the request until the TLS handshake completes, or send a 4NN (Too
 Early) status code in response.  A gateway that is uncertain about whether an
 origin server supports the `Early-Data` header field SHOULD disable early data.
 
-## TLS Implementation Requirements
+## Consistent Handling of Early Data {#be-consistent}
 
-In order to be used for early data in HTTP, A TLS implementation MUST ensure
-that it is possible to correctly identify early data.  This is necessary even
-if early data arrives at the same time as the TLS Finished message from the
-client, which completes the handshake.  If early data is misclassified, a
-server might process requests under the misapprehension that they can't be or
-weren't replayed elsewhere.
+Consistent treatment of a request that arrives in - or partially in - early data
+is critical to avoiding inappropriate processing of replayed requests.  If a
+request is not safe to process before the TLS handshake completes, then all
+instances of the server need to agree and either reject the request or delay
+processing.
 
 
 # IANA Considerations


### PR DESCRIPTION
This rescues the good text from #25, on which we are converging on consensus to reject.