### PR TITLE
Don't repeat TLS advice

### DIFF
--- a/draft-thomson-http-replay.md
+++ b/draft-thomson-http-replay.md
@@ -99,27 +99,26 @@ data on future connections when sending the TLS session ticket.
 When a server enables early data, there are a number of techniques it can use
 to mitigate the risks of replay:
 
-1. The server can choose whether it will process early data before the TLS
+1. TLS {{?TLS13}} mandates the use of replay detection strategies that reduce
+   the ability of an attacker to successfully replay early data.  These
+   anti-replay techniques reduce but don't completely eliminate the chance of
+   data being replayed and ensure a fixed upper limit to the number of replays.
+
+2. The server can choose whether it will process early data before the TLS
    handshake completes. By deferring processing, it can ensure that only a
    successfully completed connection is used for the request(s) therein.
    Assuming that a replayed ClientHello will not result in additional
    connections being made by the client, this provides the server with some
    assurance that the early data was not replayed.
 
-2. If the server receives multiple requests in early data, it can determine
+3. If the server receives multiple requests in early data, it can determine
    whether to defer HTTP processing on a per-request basis. This may require
    buffering the responses to preserve ordering in HTTP/1.1.
 
-3. The server can cause a client to retry a request and not use early data by
+4. The server can cause a client to retry a request and not use early data by
    responding with the 4NN (Too Early) status code ({{status}}), in cases where
    the risk of replay is judged too great.
 
-4. Finally, TLS {{?TLS13}} describes several mitigation strategies that reduce
-   the ability of an attacker to successfully replay early data. Servers are
-   strongly encouraged to implement these techniques, but to also recognize
-   that they are imperfect.  These anti-replay techniques can reduce the number
-   of replays that will be successful from being essentially unbounded to a
-   fixed value.
 
 For a given request, the level of tolerance to replay risk is specific to the
 resource it operates upon (and therefore only known to the origin server). In


### PR DESCRIPTION
TLS mandates the use of anti-replay, but we were implying that it didn't, so
that text needed rewording.

I've moved this to the top of the list, since it is the first line of defense.
I've reworded to emphasize that it is mandatory, but then mention that it is
imperfect.

Closes #39.